### PR TITLE
Generate JWT per user and encode username; add /meet command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM golang:1.13
 
 RUN apt update && \
     apt -y install build-essential npm && \
+    npm install -g npm@latest && \
     rm -rf /var/lib/apt/lists/*
 
 RUN addgroup --gid 1000 node \

--- a/docker-make
+++ b/docker-make
@@ -2,5 +2,5 @@
 
 set -ex
 
-sudo docker build -t mattermost-plugin-jitsi-builder .
-sudo docker run --rm -it -v $(pwd):/src -w /src mattermost-plugin-jitsi-builder make "$@"
+docker build -t mattermost-plugin-jitsi-builder .
+docker run --rm -it -v $(pwd):/src -w /src mattermost-plugin-jitsi-builder make "$@"

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,6 @@ require (
 	golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3 // indirect
 	golang.org/x/sys v0.0.0-20190405154228-4b34438f7a67 // indirect
 	golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2 // indirect
-	google.golang.org/appengine v1.4.0 // indirect
 	google.golang.org/genproto v0.0.0-20190404172233-64821d5d2107 // indirect
 	google.golang.org/grpc v1.20.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect

--- a/plugin.json
+++ b/plugin.json
@@ -8,8 +8,7 @@
             "linux-amd64": "server/dist/plugin-linux-amd64",
             "darwin-amd64": "server/dist/plugin-darwin-amd64",
             "windows-amd64": "server/dist/plugin-windows-amd64.exe"
-        },
-        "executable": ""
+        }
     },
     "webapp": {
         "bundle_path": "webapp/dist/main.js"

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -2,11 +2,13 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
 	"net/url"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -41,7 +43,9 @@ func (p *Plugin) OnActivate() error {
 }
 
 func (p *Plugin) ServeHTTP(c *plugin.Context, w http.ResponseWriter, r *http.Request) {
-	switch path := r.URL.Path; path {
+	switch r.URL.Path {
+	case "/api/v1/meetings/gentoken":
+		p.handleJWTRequest(w, r)
 	case "/api/v1/meetings":
 		p.handleStartMeeting(w, r)
 	default:
@@ -56,10 +60,34 @@ type StartMeetingRequest struct {
 	MeetingId int    `json:"meeting_id"`
 }
 
+type GenerateMeetingJWTRequest struct {
+	ChannelId      string `json:"channel_id"`
+	MeetingId      string `json:"meeting_id"`
+	MeetingOwnerId string `json:"owner_id"`
+	DisplayName    string `json:"display_name"`
+}
+
+type GenerateMeetingJWTResponse struct {
+	Token                 string `json:"jwt_token"`
+	MeetingLinkValidUntil string `json:"jwt_meeting_valid_until"`
+}
+
 // Claims extents cristalhq/jwt standard claims to add jitsi-web-token specific fields
+type ClaimsUser struct {
+	Id        string `json:"id,omitempty"`
+	Name      string `json:"name,omitempty"`
+	AvatarUrl string `json:"avatar,omitempty"`
+}
+
+type ClaimsContext struct {
+	User ClaimsUser `json:"user,omitempty"`
+}
+
 type Claims struct {
 	jwt.StandardClaims
-	Room string `json:"room,omitempty"`
+	Context     ClaimsContext `json:"context,omitempty"`
+	Room        string        `json:"room,omitempty"`
+	IsModerator bool          `json:"moderator,omitempty"`
 }
 
 // MarshalBinary default marshaling to JSON.
@@ -73,6 +101,44 @@ func encodeJitsiMeetingID(meeting string) string {
 		log.Fatal(err)
 	}
 	return reg.ReplaceAllString(meeting, "")
+}
+
+func (p *Plugin) generateJWTToken(meetingID string, displayName string) (string, string, error) {
+
+	var meetingLinkValidUntil = time.Time{}
+
+	signer, herr := jwt.NewHS256([]byte(p.getConfiguration().JitsiAppSecret))
+	if herr != nil {
+		log.Printf("Error generating new HS256 signer: %v", herr)
+		return "", "", errors.New("Internal error")
+	}
+	builder := jwt.NewTokenBuilder(signer)
+
+	// Error check is done in configuration.IsValid()
+	jURL, _ := url.Parse(p.getConfiguration().JitsiURL)
+
+	meetingLinkValidUntil = time.Now().Add(time.Duration(p.getConfiguration().JitsiLinkValidTime) * time.Minute)
+
+	claims := Claims{}
+	claims.Issuer = p.getConfiguration().JitsiAppID
+	claims.Audience = []string{p.getConfiguration().JitsiAppID}
+	claims.ExpiresAt = jwt.Timestamp(meetingLinkValidUntil.Unix())
+	claims.Subject = jURL.Hostname()
+	claims.Room = meetingID
+
+	if displayName != "" {
+		claimsContext := ClaimsContext{User: ClaimsUser{}}
+		claimsContext.User.Name = displayName
+		claims.Context = claimsContext
+	}
+
+	token, berr := builder.Build(claims)
+	if berr != nil {
+		log.Printf("Error building JWT: %v", berr)
+		return "", "", errors.New("Internal error")
+	}
+
+	return strconv.FormatInt(meetingLinkValidUntil.Unix(), 10), string(token.Raw()), nil
 }
 
 func (p *Plugin) handleStartMeeting(w http.ResponseWriter, r *http.Request) {
@@ -92,6 +158,7 @@ func (p *Plugin) handleStartMeeting(w http.ResponseWriter, r *http.Request) {
 
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
 	}
 
 	var user *model.User
@@ -99,9 +166,10 @@ func (p *Plugin) handleStartMeeting(w http.ResponseWriter, r *http.Request) {
 	user, err = p.API.GetUser(userId)
 	if err != nil {
 		http.Error(w, err.Error(), err.StatusCode)
+		return
 	}
 
-	if _, err := p.API.GetChannelMember(req.ChannelId, user.Id); err != nil {
+	if _, err = p.API.GetChannelMember(req.ChannelId, user.Id); err != nil {
 		http.Error(w, "Forbidden", http.StatusForbidden)
 		return
 	}
@@ -115,68 +183,117 @@ func (p *Plugin) handleStartMeeting(w http.ResponseWriter, r *http.Request) {
 	jitsiURL = strings.TrimRight(jitsiURL, "/")
 	meetingURL := jitsiURL + "/" + meetingID
 
-	var meetingLinkValidUntil = time.Time{}
+	message := fmt.Sprintf("Meeting started at %s.", meetingURL)
+
 	JWTMeeting := p.getConfiguration().JitsiJWT
-
 	if JWTMeeting {
-		signer, err2 := jwt.NewHS256([]byte(p.getConfiguration().JitsiAppSecret))
-		if err2 != nil {
-			log.Printf("Error generating new HS256 signer: %v", err2)
+		_, anonymousMeetingToken, err := p.generateJWTToken(meetingID, "")
+		if err != nil {
 			http.Error(w, "Internal error", http.StatusInternalServerError)
 			return
 		}
-		builder := jwt.NewTokenBuilder(signer)
-
-		// Error check is done in configuration.IsValid()
-		jURL, _ := url.Parse(p.getConfiguration().JitsiURL)
-
-		meetingLinkValidUntil = time.Now().Add(time.Duration(p.getConfiguration().JitsiLinkValidTime) * time.Minute)
-
-		claims := Claims{}
-		claims.Issuer = p.getConfiguration().JitsiAppID
-		claims.Audience = []string{p.getConfiguration().JitsiAppID}
-		claims.ExpiresAt = jwt.Timestamp(meetingLinkValidUntil.Unix())
-		claims.Subject = jURL.Hostname()
-		claims.Room = meetingID
-
-		token, err2 := builder.Build(claims)
-		if err2 != nil {
-			log.Printf("Error building JWT: %v", err2)
-			http.Error(w, "Internal error", http.StatusInternalServerError)
-			return
-		}
-
-		meetingURL = meetingURL + "?jwt=" + string(token.Raw())
+		anonymousMeetingURL := meetingURL + "?jwt=" + anonymousMeetingToken
+		message = fmt.Sprintf("Meeting started at %s. *This link includes a non-personalized access Token you see for compatibility reasons.* **Valid for %d minutes.**", anonymousMeetingURL, p.getConfiguration().JitsiLinkValidTime)
 	}
 
 	post := &model.Post{
 		UserId:    user.Id,
 		ChannelId: req.ChannelId,
-		Message:   fmt.Sprintf("Meeting started at %s.", meetingURL),
+		Message:   message,
 		Type:      "custom_jitsi",
 		Props: map[string]interface{}{
-			"meeting_id":              meetingID,
-			"meeting_link":            meetingURL,
-			"jwt_meeting":             JWTMeeting,
-			"jwt_meeting_valid_until": meetingLinkValidUntil.Format("2006-01-02 15:04:05 Z07:00"),
-			"meeting_personal":        false,
-			"meeting_topic":           req.Topic,
-			"from_webhook":            "true",
-			"override_username":       "Jitsi",
-			"override_icon_url":       "https://s3.amazonaws.com/mattermost-plugin-media/Zoom+App.png",
+			"meeting_id":        meetingID,
+			"meeting_link":      meetingURL,
+			"jwt_meeting":       JWTMeeting,
+			"meeting_personal":  false,
+			"meeting_topic":     req.Topic,
+			"from_webhook":      "true",
+			"override_username": "Jitsi",
+			"override_icon_url": "https://s3.amazonaws.com/mattermost-plugin-media/Zoom+App.png",
 		},
 	}
 
-	if _, err := p.API.CreatePost(post); err != nil {
+	if _, err = p.API.CreatePost(post); err != nil {
 		http.Error(w, err.Error(), err.StatusCode)
 		return
 	}
 
-	err = p.API.KVSet(fmt.Sprintf("%v%v", POST_MEETING_KEY, meetingID), []byte(post.Id))
-	if err != nil {
+	if err = p.API.KVSet(fmt.Sprintf("%v%v", POST_MEETING_KEY, meetingID), []byte(post.Id)); err != nil {
 		http.Error(w, err.Error(), err.StatusCode)
 		return
 	}
 
 	w.Write([]byte(fmt.Sprintf("%v", meetingID)))
+}
+
+func (p *Plugin) handleJWTRequest(w http.ResponseWriter, r *http.Request) {
+	if err := p.getConfiguration().IsValid(); err != nil {
+		http.Error(w, err.Error(), http.StatusTeapot)
+		return
+	}
+
+	userId := r.Header.Get("Mattermost-User-Id")
+
+	if userId == "" {
+		http.Error(w, "Not authorized", http.StatusUnauthorized)
+		return
+	}
+
+	var req GenerateMeetingJWTRequest
+
+	if derr := json.NewDecoder(r.Body).Decode(&req); derr != nil {
+		http.Error(w, derr.Error(), http.StatusBadRequest)
+		return
+	}
+
+	var user *model.User
+	var err *model.AppError
+	user, err = p.API.GetUser(userId)
+	if err != nil {
+		http.Error(w, err.Error(), err.StatusCode)
+	}
+
+	if _, err = p.API.GetChannelMember(req.ChannelId, user.Id); err != nil {
+		http.Error(w, "Forbidden", http.StatusForbidden)
+		return
+	}
+
+	var meetingID string
+	meetingID = req.MeetingId
+	if len(req.MeetingId) < 1 {
+		http.Error(w, "Forbidden", http.StatusBadRequest)
+		return
+	}
+
+	var displayName string
+	displayName = req.DisplayName
+	if len(req.DisplayName) < 1 {
+		displayName += user.FirstName
+		if len(displayName) > 0 && len(user.LastName) > 0 {
+			displayName += " " + user.LastName
+		}
+		if len(displayName) > 0 && len(user.Nickname) > 0 {
+			displayName += " (" + user.Nickname + ")"
+		}
+		if len(displayName) < 1 {
+			displayName = user.Username
+		}
+	}
+
+	var jwterr error
+	var jwtResponse GenerateMeetingJWTResponse
+	jwtResponse.MeetingLinkValidUntil, jwtResponse.Token, jwterr = p.generateJWTToken(meetingID, displayName)
+	if jwterr != nil {
+		http.Error(w, jwterr.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	tokenJson, jmerr := json.Marshal(jwtResponse)
+	if jmerr != nil {
+		http.Error(w, jmerr.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(tokenJson)
 }

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -15,6 +15,7 @@
     "babel-eslint": "^8.2.6",
     "babel-loader": "^7.1.5",
     "babel-plugin-transform-class-properties": "^6.24.1",
+    "babel-plugin-transform-es2015-template-literals": "^6.22.0",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^1.7.0",
     "babel-preset-react": "^6.24.1",
@@ -23,6 +24,9 @@
     "eslint-plugin-import": "^2.13.0",
     "eslint-plugin-react": "^7.10.0",
     "file-loader": "3.0.1",
+    "find-cache-dir": "^3.3.1",
+    "style-loader": "^1.1.3",
+    "css-loader": "^3.4.2",
     "webpack": "^4.16.1",
     "webpack-cli": "^3.0.8"
   },
@@ -32,6 +36,6 @@
     "react-intl": "2.8.0",
     "react-redux": "5.0.7",
     "redux": "4.0.0",
-    "superagent": "^5.0.5"
+    "react-loader-spinner": "^3.1.5"
   }
 }

--- a/webapp/src/actions/index.js
+++ b/webapp/src/actions/index.js
@@ -43,3 +43,17 @@ export function startMeeting(channelId, personal = false, topic = '', meetingId 
         return {data: true};
     };
 }
+
+export function requestJWT(channelId, meetingId, meetingOwnerId = '', displayName = '') {
+    return async () => {
+        let tokenResponse;
+        try {
+            tokenResponse = await Client.requestJWT(channelId, meetingId, meetingOwnerId, displayName);
+        } catch (error) {
+            return {data: null, token_error: error, auth: null};
+        }
+
+        return {data: true, token_error: null, auth: tokenResponse};
+    };
+}
+

--- a/webapp/src/client/client.js
+++ b/webapp/src/client/client.js
@@ -1,4 +1,6 @@
-import request from 'superagent';
+//import request from 'superagent';
+import {Client4} from 'mattermost-redux/client';
+import {ClientError} from 'mattermost-redux/client/client4';
 
 export default class Client {
     constructor() {
@@ -9,20 +11,31 @@ export default class Client {
         return this.doPost(`${this.url}/api/v1/meetings`, {channel_id: channelId, personal, topic, meeting_id: meetingId});
     }
 
+    requestJWT = async (channelId, meetingId, meetingOwnerId = '', displayName = '') => {
+        return this.doPost(`${this.url}/api/v1/meetings/gentoken`, {channel_id: channelId, meeting_id: meetingId, owner_id: meetingOwnerId, display_name: displayName});
+    }
+
     doPost = async (url, body, headers = {}) => {
+        //headers['X-Timezone-Offset'] = new Date().getTimezoneOffset();
         headers['X-Requested-With'] = 'XMLHttpRequest';
 
-        try {
-            const response = await request.
-                post(url).
-                send(body).
-                set(headers).
-                type('application/json').
-                accept('application/json');
+        const options = {
+            method: 'post',
+            body: JSON.stringify(body),
+            headers
+        };
 
-            return response.body;
-        } catch (err) {
-            throw err;
+        const response = await fetch(url, Client4.getOptions(options));
+        if (response.ok) {
+            return response.json();
         }
+
+        const text = await response.text();
+
+        throw new ClientError(Client4.url, {
+            message: text || '',
+            status_code: response.status,
+            url
+        });
     }
 }

--- a/webapp/src/components/post_type_jitsi/index.js
+++ b/webapp/src/components/post_type_jitsi/index.js
@@ -9,10 +9,12 @@ import PostTypeJitsi from './post_type_jitsi.jsx';
 function mapStateToProps(state, ownProps) {
     const post = ownProps.post || {};
     const user = state.entities.users.profiles[post.user_id] || {};
+    const us = state.entities.users.profiles[state.entities.users.currentUserId] || {};
 
     return {
         ...ownProps,
         creatorName: displayUsernameForUser(user, state.entities.general.config),
+        displayName: displayUsernameForUser(us, state.entities.general.config),
         useMilitaryTime: getBool(state, 'display_settings', 'use_military_time', false)
     };
 }

--- a/webapp/webpack.config.js
+++ b/webapp/webpack.config.js
@@ -11,7 +11,7 @@ module.exports = {
             'node_modules',
             path.resolve(__dirname)
         ],
-        extensions: ['*', '.js', '.jsx']
+        extensions: ['*', '.js', '.jsx', '.css']
     },
     module: {
         rules: [
@@ -28,6 +28,13 @@ module.exports = {
                         ]
                     }
                 }
+            },
+            {
+                test: /\.css$/,
+                use: [
+                    {loader: 'style-loader'},
+                    {loader: 'css-loader'}
+                ]
             }
         ]
     },


### PR DESCRIPTION
### Features
* Generate JWT per user and encode username, from client side (+ mobile app fallback)
* add `/meet` command; allowing
  * mobile app users to start a meeting
  * defining a meeting name `/meet [optional: my meeting name, even with spaces]`

*additionally:*
* render "token valid until"-time client-side to display time in users timezone (+ mobile app fallback)
* clean code and dependencies to allow build on clean system (in docker container) and **pass all style checking**!

#### Implementation
Meeting invitations for meetings requiring a token are sent without a token (not really, see below). Upon reception of the invitation a token is requested by the client side for the current user. The token is sent back and appended to the meeting url. (*While waiting for the token, a message and loading indicator are displayed.*)
Tokens are regenerated when re-rendering a post! The tokens validity time is now the lifetime of the token itself, NOT the time a user has to join a meeting - as tokens can be regenerated.
To be compatible with mobile users, a static, non-customized link is embedded in the messages plain text. The lifetime of the token is expressed in minutes, as the timezone can not be taken into account when falling back to plain text.

#### Security considerations
It would in theory be possible to request token generation for arbitrary usernames and channels, when forging a request against the endpoint including a full, valid "mattermost-header" and knowing a valid userID and channelID that user is part of.

---
### *"major"* rework
Split `handleStartMeeting` into:
* `handleStartMeeting`
* `startMeeting`
* `handleJWTRequest`
* `generateJWTToken`

Add new api endpoint to generate tokens at `/api/v1/meetings/gentoken`

### minor cleanup and modifications:
* `plugin.json` *cleanup*
* `package.json` added build dependencies, necessary for build on clean system or in docker container
* webapp client: removed `superagent` dependency and changed to using redux client (already present)
* `plugin.go`, clean unused:
  * `POST_MEETING_KEY`
  * unused storage of meeting id in mattermost key-value-store
* Update npm version in docker container
* remove `sudo` directives from `docker-make` as these pose a security risk and should not be necessary when user is configured correctly and added to `docker`-group
