### PR TITLE
Naming options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.4.0] - 2020-05-04
+
+-   Added name options setting so you can choose how to generate names. The options are:
+    -   Randomly-generated English titlecase e.g. PlayfulDragonsObserveCuriously (similar to how meet.jit.si operates by default)
+    -   Randomly-generated English kebabcase e.g. playful-dragons-observe-curiously
+    -   Random UUID
+    -   Random 10 digit code
+    -   Random 10 letter code
+    -   Your channel URL slug with no separators (e.g. `townsquare`)
+    -   Your channel URL slug with dash separators (e.g. `town-square`)

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM golang:1.13
 
 RUN apt update && \
     apt -y install build-essential npm && \
+    npm install -g npm@latest && \
     rm -rf /var/lib/apt/lists/*
 
 RUN addgroup --gid 1000 node \

--- a/docker-make
+++ b/docker-make
@@ -2,5 +2,5 @@
 
 set -ex
 
-sudo docker build -t mattermost-plugin-jitsi-builder .
-sudo docker run --rm -it -v $(pwd):/src -w /src mattermost-plugin-jitsi-builder make "$@"
+docker build -t mattermost-plugin-jitsi-builder .
+docker run --rm -it -v $(pwd):/src -w /src mattermost-plugin-jitsi-builder make "$@"

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,6 @@ require (
 	golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3 // indirect
 	golang.org/x/sys v0.0.0-20190405154228-4b34438f7a67 // indirect
 	golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2 // indirect
-	google.golang.org/appengine v1.4.0 // indirect
 	google.golang.org/genproto v0.0.0-20190404172233-64821d5d2107 // indirect
 	google.golang.org/grpc v1.20.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/cristalhq/jwt v1.1.1
 	github.com/dyatlov/go-opengraph v0.0.0-20180429202543-816b6608b3c8 // indirect
 	github.com/golang/protobuf v1.3.1 // indirect
-	github.com/google/uuid v1.1.1 // indirect
+	github.com/google/uuid v1.1.1
 	github.com/gorilla/websocket v1.4.0 // indirect
 	github.com/hashicorp/go-plugin v1.0.0 // indirect
 	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect

--- a/plugin.json
+++ b/plugin.json
@@ -8,8 +8,7 @@
             "linux-amd64": "server/dist/plugin-linux-amd64",
             "darwin-amd64": "server/dist/plugin-darwin-amd64",
             "windows-amd64": "server/dist/plugin-windows-amd64.exe"
-        },
-        "executable": ""
+        }
     },
     "webapp": {
         "bundle_path": "webapp/dist/main.js"

--- a/plugin.json
+++ b/plugin.json
@@ -75,12 +75,12 @@
                         "value": "letters"
                     },
                     {
-                        "display_name": "Channel name only, title-case (name conflict risk!)",
-                        "value": "channel-titlecase"
+                        "display_name": "Channel name only, no separators (name conflict risk!)",
+                        "value": "channel"
                     },
                     {
-                        "display_name": "Channel name only, kebab-case (name conflict risk!)",
-                        "value": "channel-kebabcase"
+                        "display_name": "Channel name only, separated by dashes (name conflict risk!)",
+                        "value": "channel-dashes"
                     }
                 ]
             }

--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
     "id": "jitsi",
     "name": "Jitsi",
     "description": "Jitsi audio and video conferencing plugin for Mattermost. Follow https://github.com/seansackowitz/mattermost-plugin-jitsi for notifications on updates.",
-    "version": "1.3.0",
+    "version": "1.4.0",
     "server": {
         "executables": {
             "linux-amd64": "server/dist/plugin-linux-amd64",

--- a/plugin.json
+++ b/plugin.json
@@ -46,6 +46,43 @@
                 "type": "number",
                 "help_text": "How many minutes is the generated link active, if set smaller then 1, valid time is automaticaly set to 30 minutes.",
                 "default": 30
+            },
+            {
+                "key": "JitsiNamingScheme",
+                "display_name": "Meeting naming scheme",
+                "type": "radio",
+                "help_text": "How should the plugin choose a meeting name? Some names may cause conflicts if you use them on a public server, like meet.jit.si.",
+                "default": "english-titlecase",
+                "options": [
+                    {
+                        "display_name": "English words, title-case (e.g. PlayfulDragonsObserveCuriously)",
+                        "value": "english-titlecase"
+                    },
+                    {
+                        "display_name": "English words, kebab-case (e.g. playful-dragons-observe-curiously)",
+                        "value": "english-kebabcase"
+                    },
+                    {
+                        "display_name": "UUID",
+                        "value": "uuid"
+                    },
+                    {
+                        "display_name": "10 digit code (name conflict risk!)",
+                        "value": "digits"
+                    },
+                    {
+                        "display_name": "10 letter code (name conflict risk!)",
+                        "value": "letters"
+                    },
+                    {
+                        "display_name": "Channel name only, title-case (name conflict risk!)",
+                        "value": "channel-titlecase"
+                    },
+                    {
+                        "display_name": "Channel name only, kebab-case (name conflict risk!)",
+                        "value": "channel-kebabcase"
+                    }
+                ]
             }
         ]
     }

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -28,6 +28,7 @@ type configuration struct {
 	JitsiAppID         string
 	JitsiAppSecret     string
 	JitsiLinkValidTime int
+	JitsiNamingScheme  string
 }
 
 // Clone shallow copies the configuration. Your implementation may require a deep copy if

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -2,11 +2,13 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
 	"net/url"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -17,7 +19,7 @@ import (
 )
 
 const (
-	POST_MEETING_KEY = "post_meeting_"
+	JITSI_COMMAND = "meet"
 )
 
 type Plugin struct {
@@ -37,11 +39,21 @@ func (p *Plugin) OnActivate() error {
 		return err
 	}
 
+	if cerr := p.API.RegisterCommand(&model.Command{
+		Trigger:          JITSI_COMMAND,
+		AutoComplete:     true,
+		AutoCompleteDesc: "Start a Jitsi meeting for the current channel. Optionally, append desired meeting topic after the command",
+	}); cerr != nil {
+		return cerr
+	}
+
 	return nil
 }
 
 func (p *Plugin) ServeHTTP(c *plugin.Context, w http.ResponseWriter, r *http.Request) {
-	switch path := r.URL.Path; path {
+	switch r.URL.Path {
+	case "/api/v1/meetings/gentoken":
+		p.handleJWTRequest(w, r)
 	case "/api/v1/meetings":
 		p.handleStartMeeting(w, r)
 	default:
@@ -56,10 +68,34 @@ type StartMeetingRequest struct {
 	MeetingId int    `json:"meeting_id"`
 }
 
+type GenerateMeetingJWTRequest struct {
+	ChannelId      string `json:"channel_id"`
+	MeetingId      string `json:"meeting_id"`
+	MeetingOwnerId string `json:"owner_id"`
+	DisplayName    string `json:"display_name"`
+}
+
+type GenerateMeetingJWTResponse struct {
+	Token                 string `json:"jwt_token"`
+	MeetingLinkValidUntil string `json:"jwt_meeting_valid_until"`
+}
+
 // Claims extents cristalhq/jwt standard claims to add jitsi-web-token specific fields
+type ClaimsUser struct {
+	Id        string `json:"id,omitempty"`
+	Name      string `json:"name,omitempty"`
+	AvatarUrl string `json:"avatar,omitempty"`
+}
+
+type ClaimsContext struct {
+	User ClaimsUser `json:"user,omitempty"`
+}
+
 type Claims struct {
 	jwt.StandardClaims
-	Room string `json:"room,omitempty"`
+	Context     ClaimsContext `json:"context,omitempty"`
+	Room        string        `json:"room,omitempty"`
+	IsModerator bool          `json:"moderator,omitempty"`
 }
 
 // MarshalBinary default marshaling to JSON.
@@ -73,6 +109,114 @@ func encodeJitsiMeetingID(meeting string) string {
 		log.Fatal(err)
 	}
 	return reg.ReplaceAllString(meeting, "")
+}
+
+func (p *Plugin) generateJWTToken(meetingID string, displayName string) (string, string, error) {
+
+	var meetingLinkValidUntil = time.Time{}
+
+	signer, herr := jwt.NewHS256([]byte(p.getConfiguration().JitsiAppSecret))
+	if herr != nil {
+		log.Printf("Error generating new HS256 signer: %v", herr)
+		return "", "", errors.New("Internal error")
+	}
+	builder := jwt.NewTokenBuilder(signer)
+
+	// Error check is done in configuration.IsValid()
+	jURL, _ := url.Parse(p.getConfiguration().JitsiURL)
+
+	meetingLinkValidUntil = time.Now().Add(time.Duration(p.getConfiguration().JitsiLinkValidTime) * time.Minute)
+
+	claims := Claims{}
+	claims.Issuer = p.getConfiguration().JitsiAppID
+	claims.Audience = []string{p.getConfiguration().JitsiAppID}
+	claims.ExpiresAt = jwt.Timestamp(meetingLinkValidUntil.Unix())
+	claims.Subject = jURL.Hostname()
+	claims.Room = meetingID
+
+	if displayName != "" {
+		claimsContext := ClaimsContext{User: ClaimsUser{}}
+		claimsContext.User.Name = displayName
+		claims.Context = claimsContext
+	}
+
+	token, berr := builder.Build(claims)
+	if berr != nil {
+		log.Printf("Error building JWT: %v", berr)
+		return "", "", errors.New("Internal error")
+	}
+
+	return strconv.FormatInt(meetingLinkValidUntil.Unix(), 10), string(token.Raw()), nil
+}
+
+func (p *Plugin) startMeeting(userId string, channelId string, meetingTopic string) error {
+	var meetingID string
+	meetingID = encodeJitsiMeetingID(meetingTopic)
+	if len(meetingID) < 1 {
+		meetingID = generateRoomWithoutSeparator()
+	}
+	jitsiURL := strings.TrimSpace(p.getConfiguration().JitsiURL)
+	jitsiURL = strings.TrimRight(jitsiURL, "/")
+	meetingURL := jitsiURL + "/" + meetingID
+
+	message := fmt.Sprintf("Meeting started at %s.", meetingURL)
+
+	JWTMeeting := p.getConfiguration().JitsiJWT
+	if JWTMeeting {
+		_, anonymousMeetingToken, err := p.generateJWTToken(meetingID, "")
+		if err != nil {
+			return err
+		}
+		anonymousMeetingURL := meetingURL + "?jwt=" + anonymousMeetingToken
+		message = fmt.Sprintf("Meeting started at %s. *This link includes a non-personalized access Token you see for compatibility reasons.* **Valid for %d minutes.**", anonymousMeetingURL, p.getConfiguration().JitsiLinkValidTime)
+	}
+
+	post := &model.Post{
+		UserId:    userId,
+		ChannelId: channelId,
+		Message:   message,
+		Type:      "custom_jitsi",
+		Props: map[string]interface{}{
+			"meeting_id":       meetingID,
+			"meeting_link":     meetingURL,
+			"jwt_meeting":      JWTMeeting,
+			"meeting_personal": false,
+			"meeting_topic":    meetingTopic,
+		},
+	}
+
+	if _, err := p.API.CreatePost(post); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*model.CommandResponse, *model.AppError) {
+	input := strings.TrimSpace(strings.TrimPrefix(args.Command, "/"+JITSI_COMMAND))
+
+	if err := p.startMeeting(args.UserId, args.ChannelId, input); err != nil {
+		/*
+			msg := &model.Post{
+				UserId:    args.UserId,
+				ChannelId: args.ChannelId,
+				Message:   "We could not start a meeting at this time.",
+				//Type:      "custom_jitsi",
+				//Props: map[string]interface{}{},
+			}
+			p.API.SendEphemeralPost(args.UserId, msg)
+		*/
+		return &model.CommandResponse{
+				ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL,
+				ChannelId:    args.ChannelId,
+				Text:         "We could not start a meeting at this time.",
+			}, &model.AppError{
+				Message:       "We could not start a meeting at this time.",
+				DetailedError: fmt.Sprintf("startMeeting() threw error: %s", err),
+			}
+	}
+
+	return &model.CommandResponse{}, nil
 }
 
 func (p *Plugin) handleStartMeeting(w http.ResponseWriter, r *http.Request) {
@@ -92,6 +236,54 @@ func (p *Plugin) handleStartMeeting(w http.ResponseWriter, r *http.Request) {
 
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	var user *model.User
+	var err *model.AppError
+	user, err = p.API.GetUser(userId)
+	if err != nil {
+		http.Error(w, err.Error(), err.StatusCode)
+		return
+	}
+
+	if _, err = p.API.GetChannelMember(req.ChannelId, user.Id); err != nil {
+		http.Error(w, "Forbidden", http.StatusForbidden)
+		return
+	}
+
+	if merr := p.startMeeting(user.Id, req.ChannelId, req.Topic); merr != nil {
+		http.Error(w, "Internal error", http.StatusInternalServerError)
+	}
+
+	/*
+		if err = p.API.KVSet(fmt.Sprintf("%v%v", POST_MEETING_KEY, meetingID), []byte(post.Id)); err != nil {
+			http.Error(w, err.Error(), err.StatusCode)
+			return
+		}
+	*/
+
+	w.Write([]byte("OK"))
+}
+
+func (p *Plugin) handleJWTRequest(w http.ResponseWriter, r *http.Request) {
+	if err := p.getConfiguration().IsValid(); err != nil {
+		http.Error(w, err.Error(), http.StatusTeapot)
+		return
+	}
+
+	userId := r.Header.Get("Mattermost-User-Id")
+
+	if userId == "" {
+		http.Error(w, "Not authorized", http.StatusUnauthorized)
+		return
+	}
+
+	var req GenerateMeetingJWTRequest
+
+	if derr := json.NewDecoder(r.Body).Decode(&req); derr != nil {
+		http.Error(w, derr.Error(), http.StatusBadRequest)
+		return
 	}
 
 	var user *model.User
@@ -101,82 +293,47 @@ func (p *Plugin) handleStartMeeting(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), err.StatusCode)
 	}
 
-	if _, err := p.API.GetChannelMember(req.ChannelId, user.Id); err != nil {
+	if _, err = p.API.GetChannelMember(req.ChannelId, user.Id); err != nil {
 		http.Error(w, "Forbidden", http.StatusForbidden)
 		return
 	}
 
 	var meetingID string
-	meetingID = encodeJitsiMeetingID(req.Topic)
-	if len(req.Topic) < 1 {
-		meetingID = generateRoomWithoutSeparator()
-	}
-	jitsiURL := strings.TrimSpace(p.getConfiguration().JitsiURL)
-	jitsiURL = strings.TrimRight(jitsiURL, "/")
-	meetingURL := jitsiURL + "/" + meetingID
-
-	var meetingLinkValidUntil = time.Time{}
-	JWTMeeting := p.getConfiguration().JitsiJWT
-
-	if JWTMeeting {
-		signer, err2 := jwt.NewHS256([]byte(p.getConfiguration().JitsiAppSecret))
-		if err2 != nil {
-			log.Printf("Error generating new HS256 signer: %v", err2)
-			http.Error(w, "Internal error", http.StatusInternalServerError)
-			return
-		}
-		builder := jwt.NewTokenBuilder(signer)
-
-		// Error check is done in configuration.IsValid()
-		jURL, _ := url.Parse(p.getConfiguration().JitsiURL)
-
-		meetingLinkValidUntil = time.Now().Add(time.Duration(p.getConfiguration().JitsiLinkValidTime) * time.Minute)
-
-		claims := Claims{}
-		claims.Issuer = p.getConfiguration().JitsiAppID
-		claims.Audience = []string{p.getConfiguration().JitsiAppID}
-		claims.ExpiresAt = jwt.Timestamp(meetingLinkValidUntil.Unix())
-		claims.Subject = jURL.Hostname()
-		claims.Room = meetingID
-
-		token, err2 := builder.Build(claims)
-		if err2 != nil {
-			log.Printf("Error building JWT: %v", err2)
-			http.Error(w, "Internal error", http.StatusInternalServerError)
-			return
-		}
-
-		meetingURL = meetingURL + "?jwt=" + string(token.Raw())
-	}
-
-	post := &model.Post{
-		UserId:    user.Id,
-		ChannelId: req.ChannelId,
-		Message:   fmt.Sprintf("Meeting started at %s.", meetingURL),
-		Type:      "custom_jitsi",
-		Props: map[string]interface{}{
-			"meeting_id":              meetingID,
-			"meeting_link":            meetingURL,
-			"jwt_meeting":             JWTMeeting,
-			"jwt_meeting_valid_until": meetingLinkValidUntil.Format("2006-01-02 15:04:05 Z07:00"),
-			"meeting_personal":        false,
-			"meeting_topic":           req.Topic,
-			"from_webhook":            "true",
-			"override_username":       "Jitsi",
-			"override_icon_url":       "https://s3.amazonaws.com/mattermost-plugin-media/Zoom+App.png",
-		},
-	}
-
-	if _, err := p.API.CreatePost(post); err != nil {
-		http.Error(w, err.Error(), err.StatusCode)
+	meetingID = req.MeetingId
+	if len(req.MeetingId) < 1 {
+		http.Error(w, "Forbidden", http.StatusBadRequest)
 		return
 	}
 
-	err = p.API.KVSet(fmt.Sprintf("%v%v", POST_MEETING_KEY, meetingID), []byte(post.Id))
-	if err != nil {
-		http.Error(w, err.Error(), err.StatusCode)
+	var displayName string
+	displayName = req.DisplayName
+	if len(req.DisplayName) < 1 {
+		displayName += user.FirstName
+		if len(displayName) > 0 && len(user.LastName) > 0 {
+			displayName += " " + user.LastName
+		}
+		if len(displayName) > 0 && len(user.Nickname) > 0 {
+			displayName += " (" + user.Nickname + ")"
+		}
+		if len(displayName) < 1 {
+			displayName = user.Username
+		}
+	}
+
+	var jwterr error
+	var jwtResponse GenerateMeetingJWTResponse
+	jwtResponse.MeetingLinkValidUntil, jwtResponse.Token, jwterr = p.generateJWTToken(meetingID, displayName)
+	if jwterr != nil {
+		http.Error(w, jwterr.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	w.Write([]byte(fmt.Sprintf("%v", meetingID)))
+	tokenJson, jmerr := json.Marshal(jwtResponse)
+	if jmerr != nil {
+		http.Error(w, jmerr.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(tokenJson)
 }

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -154,10 +154,14 @@ func (p *Plugin) startMeeting(userId string, channelId string, meetingTopic stri
 	meetingID = encodeJitsiMeetingID(meetingTopic)
 	if len(meetingID) < 1 {
 		namingScheme := p.getConfiguration().JitsiNamingScheme
-		channelName, channelErr := p.API.GetChannel(channelId)
+
+		var channelName string
+		channel, channelErr := p.API.GetChannel(channelId)
 
 		if channelErr != nil {
-			channelName = ""
+			channelName = "unknown-channel"
+		} else {
+			channelName = channel.Name
 		}
 
 		meetingID = generateNameFromSelectedScheme(namingScheme, channelName)

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -153,7 +153,14 @@ func (p *Plugin) startMeeting(userId string, channelId string, meetingTopic stri
 	var meetingID string
 	meetingID = encodeJitsiMeetingID(meetingTopic)
 	if len(meetingID) < 1 {
-		meetingID = generateRoomWithoutSeparator()
+		namingScheme := p.getConfiguration().JitsiNamingScheme
+		channelName, channelErr := p.API.GetChannel(channelId)
+
+		if channelErr != nil {
+			channelName = ""
+		}
+
+		meetingID = generateNameFromSelectedScheme(namingScheme, channelName)
 	}
 	jitsiURL := strings.TrimSpace(p.getConfiguration().JitsiURL)
 	jitsiURL = strings.TrimRight(jitsiURL, "/")

--- a/server/randomNameGenerator.go
+++ b/server/randomNameGenerator.go
@@ -1,10 +1,12 @@
 package main
 
 import (
-	"math/rand"
-	"time"
-	"strings"
 	guuid "github.com/google/uuid"
+	"log"
+	"math/rand"
+	"regexp"
+	"strings"
+	"time"
 )
 
 var PLURALNOUN = []string{"Aliens", "Animals", "Antelopes", "Ants", "Apes", "Apples", "Baboons",
@@ -114,17 +116,17 @@ var NUMBERS = []rune("0123456789")
 func randomString(runes []rune, n int) string {
 	b := make([]rune, n)
 	for i := range b {
-		b[i] = runes[rand.Intn(len(letter))]
+		b[i] = runes[rand.Intn(len(runes))]
 	}
 	return string(b)
 }
 
 func generateEnglishName(delimiter string) string {
-	var components = []string {
+	var components = []string{
 		randomElement(ADJECTIVE),
 		randomElement(PLURALNOUN),
 		randomElement(VERB),
-		randomElement(ADVERB)
+		randomElement(ADVERB),
 	}
 	return strings.Join(components, delimiter)
 }
@@ -143,15 +145,15 @@ func generateUUIDName() string {
 }
 
 func generateDigitsName() string {
-	return randomString(NUMBERS)
+	return randomString(NUMBERS, 10)
 }
 
 func generateLettersName() string {
-	return randomString(LETTERS)
+	return randomString(LETTERS, 10)
 }
 
 func generateChannelName(channelName string, delimiter string) string {
-  reg, err := regexp.Compile("[^a-zA-Z0-9]+")
+	reg, err := regexp.Compile("[^a-zA-Z0-9]+")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/server/randomNameGenerator.go
+++ b/server/randomNameGenerator.go
@@ -3,6 +3,8 @@ package main
 import (
 	"math/rand"
 	"time"
+	"strings"
+	guuid "github.com/google/uuid"
 )
 
 var PLURALNOUN = []string{"Aliens", "Animals", "Antelopes", "Ants", "Apes", "Apples", "Baboons",
@@ -106,6 +108,73 @@ func randomElement(s []string) string {
 	return s[rand.Intn(len(s)-1)]
 }
 
-func generateRoomWithoutSeparator() string {
-	return (randomElement(ADJECTIVE) + randomElement(PLURALNOUN) + randomElement(VERB) + randomElement(ADVERB))
+var LETTERS = []rune("abcdefghijklmnopqrstuvwxyz")
+var NUMBERS = []rune("0123456789")
+
+func randomString(runes []rune, n int) string {
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = runes[rand.Intn(len(letter))]
+	}
+	return string(b)
+}
+
+func generateEnglishName(delimiter string) string {
+	var components = []string {
+		randomElement(ADJECTIVE),
+		randomElement(PLURALNOUN),
+		randomElement(VERB),
+		randomElement(ADVERB)
+	}
+	return strings.Join(components, delimiter)
+}
+
+func generateEnglishTitleName() string {
+	return generateEnglishName("")
+}
+
+func generateEnglishKebabName() string {
+	return strings.ToLower(generateEnglishName("-"))
+}
+
+func generateUUIDName() string {
+	id := guuid.New()
+	return (id.String())
+}
+
+func generateDigitsName() string {
+	return randomString(NUMBERS)
+}
+
+func generateLettersName() string {
+	return randomString(LETTERS)
+}
+
+func generateChannelName(channelName string, delimiter string) string {
+  reg, err := regexp.Compile("[^a-zA-Z0-9]+")
+	if err != nil {
+		log.Fatal(err)
+	}
+	return reg.ReplaceAllString(channelName, delimiter)
+}
+
+func generateNameFromSelectedScheme(namingScheme string, channelName string) string {
+	switch namingScheme {
+	case "english-titlecase":
+		return generateEnglishTitleName()
+	case "english-kebabcase":
+		return generateEnglishKebabName()
+	case "uuid":
+		return generateUUIDName()
+	case "digits":
+		return generateDigitsName()
+	case "letters":
+		return generateLettersName()
+	case "channel":
+		return generateChannelName(channelName, "")
+	case "channel-dashes":
+		return generateChannelName(channelName, "-")
+	default:
+		return generateEnglishTitleName()
+	}
 }

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -15,6 +15,7 @@
     "babel-eslint": "^8.2.6",
     "babel-loader": "^7.1.5",
     "babel-plugin-transform-class-properties": "^6.24.1",
+    "babel-plugin-transform-es2015-template-literals": "^6.22.0",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^1.7.0",
     "babel-preset-react": "^6.24.1",
@@ -23,6 +24,9 @@
     "eslint-plugin-import": "^2.13.0",
     "eslint-plugin-react": "^7.10.0",
     "file-loader": "3.0.1",
+    "find-cache-dir": "^3.3.1",
+    "style-loader": "^1.1.3",
+    "css-loader": "^3.4.2",
     "webpack": "^4.16.1",
     "webpack-cli": "^3.0.8"
   },
@@ -32,6 +36,6 @@
     "react-intl": "2.8.0",
     "react-redux": "5.0.7",
     "redux": "4.0.0",
-    "superagent": "^5.0.5"
+    "react-loader-spinner": "^3.1.5"
   }
 }

--- a/webapp/src/actions/index.js
+++ b/webapp/src/actions/index.js
@@ -43,3 +43,17 @@ export function startMeeting(channelId, personal = false, topic = '', meetingId 
         return {data: true};
     };
 }
+
+export function requestJWT(channelId, meetingId, meetingOwnerId = '', displayName = '') {
+    return async () => {
+        let tokenResponse;
+        try {
+            tokenResponse = await Client.requestJWT(channelId, meetingId, meetingOwnerId, displayName);
+        } catch (error) {
+            return {data: null, token_error: error, auth: null};
+        }
+
+        return {data: true, token_error: null, auth: tokenResponse};
+    };
+}
+

--- a/webapp/src/client/client.js
+++ b/webapp/src/client/client.js
@@ -1,4 +1,6 @@
-import request from 'superagent';
+//import request from 'superagent';
+import {Client4} from 'mattermost-redux/client';
+import {ClientError} from 'mattermost-redux/client/client4';
 
 export default class Client {
     constructor() {
@@ -9,20 +11,31 @@ export default class Client {
         return this.doPost(`${this.url}/api/v1/meetings`, {channel_id: channelId, personal, topic, meeting_id: meetingId});
     }
 
+    requestJWT = async (channelId, meetingId, meetingOwnerId = '', displayName = '') => {
+        return this.doPost(`${this.url}/api/v1/meetings/gentoken`, {channel_id: channelId, meeting_id: meetingId, owner_id: meetingOwnerId, display_name: displayName});
+    }
+
     doPost = async (url, body, headers = {}) => {
+        //headers['X-Timezone-Offset'] = new Date().getTimezoneOffset();
         headers['X-Requested-With'] = 'XMLHttpRequest';
 
-        try {
-            const response = await request.
-                post(url).
-                send(body).
-                set(headers).
-                type('application/json').
-                accept('application/json');
+        const options = {
+            method: 'post',
+            body: JSON.stringify(body),
+            headers
+        };
 
-            return response.body;
-        } catch (err) {
-            throw err;
+        const response = await fetch(url, Client4.getOptions(options));
+        if (response.ok) {
+            return response.json();
         }
+
+        const text = await response.text();
+
+        throw new ClientError(Client4.url, {
+            message: text || '',
+            status_code: response.status,
+            url
+        });
     }
 }

--- a/webapp/src/components/post_type_jitsi/index.js
+++ b/webapp/src/components/post_type_jitsi/index.js
@@ -9,10 +9,12 @@ import PostTypeJitsi from './post_type_jitsi.jsx';
 function mapStateToProps(state, ownProps) {
     const post = ownProps.post || {};
     const user = state.entities.users.profiles[post.user_id] || {};
+    const us = state.entities.users.profiles[state.entities.users.currentUserId] || {};
 
     return {
         ...ownProps,
         creatorName: displayUsernameForUser(user, state.entities.general.config),
+        displayName: displayUsernameForUser(us, state.entities.general.config),
         useMilitaryTime: getBool(state, 'display_settings', 'use_military_time', false)
     };
 }

--- a/webapp/webpack.config.js
+++ b/webapp/webpack.config.js
@@ -11,7 +11,7 @@ module.exports = {
             'node_modules',
             path.resolve(__dirname)
         ],
-        extensions: ['*', '.js', '.jsx']
+        extensions: ['*', '.js', '.jsx', '.css']
     },
     module: {
         rules: [
@@ -28,6 +28,13 @@ module.exports = {
                         ]
                     }
                 }
+            },
+            {
+                test: /\.css$/,
+                use: [
+                    {loader: 'style-loader'},
+                    {loader: 'css-loader'}
+                ]
             }
         ]
     },


### PR DESCRIPTION
PR builds off of https://github.com/seansackowitz/mattermost-plugin-jitsi/pull/26 (as the first squashed commit in this PR) and is inspired by https://github.com/seansackowitz/mattermost-plugin-jitsi/pull/21 as well.

This PR adds a settings option where the user can choose between different naming schemes:
    -   Randomly-generated English titlecase e.g. PlayfulDragonsObserveCuriously (similar to how meet.jit.si operates by default)
    -   Randomly-generated English kebabcase e.g. playful-dragons-observe-curiously
    -   Random UUID
    -   Random 10 digit code
    -   Random 10 letter code
    -   Your channel URL slug with no separators (e.g. `townsquare`)
    -   Your channel URL slug with dash separators (e.g. `town-square`)