### PR TITLE
Add user information using jwt

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -18,6 +18,8 @@ type StartMeetingRequest struct {
 
 func (p *Plugin) ServeHTTP(c *plugin.Context, w http.ResponseWriter, r *http.Request) {
 	switch path := r.URL.Path; path {
+	case "/api/v1/meetings/enrich":
+		p.handleEnrichMeetingJwt(w, r)
 	case "/api/v1/meetings":
 		p.handleStartMeeting(w, r)
 	default:

--- a/server/api.go
+++ b/server/api.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"encoding/json"
-	"fmt"
+	"log"
 	"net/http"
 
+	"github.com/mattermost/mattermost-server/v5/model"
 	"github.com/mattermost/mattermost-server/v5/plugin"
 )
 
@@ -66,5 +67,61 @@ func (p *Plugin) handleStartMeeting(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Write([]byte(fmt.Sprintf("%v", meetingID)))
+	b, err2 := json.Marshal(map[string]string{"meeting_id": meetingID})
+	if err2 != nil {
+		log.Printf("Error marshalling the MeetingID to json: %v", err2)
+		http.Error(w, "Internal error", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(b)
+}
+
+func (p *Plugin) handleEnrichMeetingJwt(w http.ResponseWriter, r *http.Request) {
+	if err := p.getConfiguration().IsValid(); err != nil {
+		http.Error(w, err.Error(), http.StatusTeapot)
+		return
+	}
+
+	userId := r.Header.Get("Mattermost-User-Id")
+	if userId == "" {
+		http.Error(w, "Not authorized", http.StatusUnauthorized)
+		return
+	}
+
+	var req EnrichMeetingJwtRequest
+
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+	}
+
+	var user *model.User
+	var err *model.AppError
+	user, err = p.API.GetUser(userId)
+	if err != nil {
+		http.Error(w, err.Error(), err.StatusCode)
+	}
+
+	JWTMeeting := p.getConfiguration().JitsiJWT
+
+	if !JWTMeeting {
+		http.Error(w, "Not authorized", http.StatusUnauthorized)
+		return
+	}
+
+	meetingJWT, err2 := p.updateJwtUserInfo(req.Jwt, user)
+	if err2 != nil {
+		log.Printf("Error updating JWT context: %v", err2)
+		http.Error(w, "Internal error", http.StatusInternalServerError)
+		return
+	}
+
+	b, err2 := json.Marshal(map[string]string{"jwt": meetingJWT})
+	if err2 != nil {
+		log.Printf("Error marshalling the JWT json: %v", err2)
+		http.Error(w, "Internal error", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(b)
 }

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -169,6 +169,7 @@ func (p *Plugin) startMeeting(user *model.User, channel *model.Channel, meetingT
 
 	var meetingLinkValidUntil = time.Time{}
 	JWTMeeting := p.getConfiguration().JitsiJWT
+	var jwtToken string
 
 	if JWTMeeting {
 		// Error check is done in configuration.IsValid()
@@ -183,7 +184,8 @@ func (p *Plugin) startMeeting(user *model.User, channel *model.Channel, meetingT
 		claims.Subject = jURL.Hostname()
 		claims.Room = meetingID
 
-		jwtToken, err2 := signClaims(p.getConfiguration().JitsiAppSecret, &claims)
+		var err2 error
+		jwtToken, err2 = signClaims(p.getConfiguration().JitsiAppSecret, &claims)
 		if err2 != nil {
 			return "", err2
 		}
@@ -200,6 +202,7 @@ func (p *Plugin) startMeeting(user *model.User, channel *model.Channel, meetingT
 			"meeting_id":              meetingID,
 			"meeting_link":            meetingLink,
 			"jwt_meeting":             JWTMeeting,
+			"meeting_jwt":             jwtToken,
 			"jwt_meeting_valid_until": meetingLinkValidUntil.Format("2006-01-02 15:04:05 Z07:00"),
 			"meeting_personal":        false,
 			"meeting_topic":           meetingTopic,

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -107,7 +107,6 @@ func signClaims(secret string, claims *Claims) (string, error) {
 }
 
 func (p *Plugin) updateJwtUserInfo(jwtToken string, user *model.User) (string, error) {
-	config := p.API.GetConfig()
 	secret := p.getConfiguration().JitsiAppSecret
 
 	claims, err := verifyJwt(secret, jwtToken)
@@ -115,8 +114,14 @@ func (p *Plugin) updateJwtUserInfo(jwtToken string, user *model.User) (string, e
 		return "", err
 	}
 
-	user.Sanitize(config.GetSanitizeOptions())
-
+	config := p.API.GetConfig()
+	if config.PrivacySettings.ShowFullName == nil || *config.PrivacySettings.ShowFullName == false {
+		user.FirstName = ""
+		user.LastName = ""
+	}
+	if config.PrivacySettings.ShowEmailAddress == nil || *config.PrivacySettings.ShowEmailAddress == false {
+		user.Email = ""
+	}
 	newContext := Context{
 		User: User{
 			Avatar: fmt.Sprintf("%s/api/v4/users/%s/image?_=%d", *config.ServiceSettings.SiteURL, user.Id, user.LastPictureUpdate),

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -115,6 +115,8 @@ func (p *Plugin) updateJwtUserInfo(jwtToken string, user *model.User) (string, e
 		return "", err
 	}
 
+	user.Sanitize(config.GetSanitizeOptions())
+
 	newContext := Context{
 		User: User{
 			Avatar: fmt.Sprintf("%s/api/v4/users/%s/image?_=%d", *config.ServiceSettings.SiteURL, user.Id, user.LastPictureUpdate),

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -48,10 +48,86 @@ func (p *Plugin) OnActivate() error {
 	return nil
 }
 
+type User struct {
+	Avatar string `json:"avatar"`
+	Name   string `json:"name"`
+	Email  string `json:"email"`
+	Id     string `json:"id"`
+}
+
+type Context struct {
+	User  User   `json:"user"`
+	Group string `json:"group"`
+}
+
+type EnrichMeetingJwtRequest struct {
+	Jwt string `json:"jwt"`
+}
+
 // Claims extents cristalhq/jwt standard claims to add jitsi-web-token specific fields
 type Claims struct {
 	jwt.StandardClaims
-	Room string `json:"room,omitempty"`
+	Context Context `json:"context"`
+	Room    string  `json:"room,omitempty"`
+}
+
+func verifyJwt(secret string, jwtToken string) (*Claims, error) {
+	verifier, err := jwt.NewVerifierHS(jwt.HS256, []byte(secret))
+	if err != nil {
+		log.Printf("Error generating new HS256 signer: %v", err)
+		return nil, err
+	}
+
+	newToken, err := jwt.ParseAndVerifyString(jwtToken, verifier)
+	if err != nil {
+		log.Printf("Error parsing or verifiying jwt: %v", err)
+		return nil, err
+	}
+
+	var claims Claims
+	if err = json.Unmarshal(newToken.RawClaims(), &claims); err != nil {
+		log.Printf("Error unmarshalling claims from jwt: %v", err)
+		return nil, err
+	}
+	return &claims, nil
+}
+
+func signClaims(secret string, claims *Claims) (string, error) {
+	signer, err2 := jwt.NewSignerHS(jwt.HS256, []byte(secret))
+	if err2 != nil {
+		log.Printf("Error generating new HS256 signer: %v", err2)
+		return "", errors.New("Internal error")
+	}
+	builder := jwt.NewBuilder(signer)
+	token, err := builder.Build(claims)
+	if err != nil {
+		return "", err
+	}
+	return string(token.Raw()), nil
+}
+
+func (p *Plugin) updateJwtUserInfo(jwtToken string, user *model.User) (string, error) {
+	config := p.API.GetConfig()
+	secret := p.getConfiguration().JitsiAppSecret
+
+	claims, err := verifyJwt(secret, jwtToken)
+	if err != nil {
+		return "", err
+	}
+
+	newContext := Context{
+		User: User{
+			Avatar: fmt.Sprintf("%s/api/v4/users/%s/image?_=%d", *config.ServiceSettings.SiteURL, user.Id, user.LastPictureUpdate),
+			Name:   user.GetDisplayName(model.SHOW_NICKNAME_FULLNAME),
+			Email:  user.Email,
+			Id:     user.Id,
+		},
+		Group: claims.Context.Group,
+	}
+
+	claims.Context = newContext
+
+	return signClaims(secret, claims)
 }
 
 func (p *Plugin) startMeeting(user *model.User, channel *model.Channel, meetingTopic string, personal bool) (string, error) {
@@ -89,18 +165,12 @@ func (p *Plugin) startMeeting(user *model.User, channel *model.Channel, meetingT
 	jitsiURL := strings.TrimSpace(p.getConfiguration().JitsiURL)
 	jitsiURL = strings.TrimRight(jitsiURL, "/")
 	meetingURL := jitsiURL + "/" + meetingID
+	meetingLink := meetingURL
 
 	var meetingLinkValidUntil = time.Time{}
 	JWTMeeting := p.getConfiguration().JitsiJWT
 
 	if JWTMeeting {
-		signer, err2 := jwt.NewSignerHS(jwt.HS256, []byte(p.getConfiguration().JitsiAppSecret))
-		if err2 != nil {
-			log.Printf("Error generating new HS256 signer: %v", err2)
-			return "", errors.New("Internal error")
-		}
-		builder := jwt.NewBuilder(signer)
-
 		// Error check is done in configuration.IsValid()
 		jURL, _ := url.Parse(p.getConfiguration().JitsiURL)
 
@@ -113,13 +183,12 @@ func (p *Plugin) startMeeting(user *model.User, channel *model.Channel, meetingT
 		claims.Subject = jURL.Hostname()
 		claims.Room = meetingID
 
-		token, err2 := builder.Build(claims)
+		jwtToken, err2 := signClaims(p.getConfiguration().JitsiAppSecret, &claims)
 		if err2 != nil {
-			log.Printf("Error building JWT: %v", err2)
 			return "", err2
 		}
 
-		meetingURL = meetingURL + "?jwt=" + string(token.Raw())
+		meetingURL = meetingURL + "?jwt=" + jwtToken
 	}
 
 	post := &model.Post{
@@ -129,7 +198,7 @@ func (p *Plugin) startMeeting(user *model.User, channel *model.Channel, meetingT
 		Type:      "custom_jitsi",
 		Props: map[string]interface{}{
 			"meeting_id":              meetingID,
-			"meeting_link":            meetingURL,
+			"meeting_link":            meetingLink,
 			"jwt_meeting":             JWTMeeting,
 			"jwt_meeting_valid_until": meetingLinkValidUntil.Format("2006-01-02 15:04:05 Z07:00"),
 			"meeting_personal":        false,

--- a/webapp/src/actions/index.js
+++ b/webapp/src/actions/index.js
@@ -43,3 +43,14 @@ export function startMeeting(channelId, personal = false, topic = '', meetingId 
         return {data: true};
     };
 }
+
+export function enrichMeetingJwt(meetingJwt) {
+    return async (dispatch, getState) => {
+        try {
+            const data = await Client.enrichMeetingJwt(meetingJwt);
+            return {data};
+        } catch (error) {
+            return {error};
+        }
+    };
+}

--- a/webapp/src/client/client.js
+++ b/webapp/src/client/client.js
@@ -13,6 +13,10 @@ export default class Client {
         return this.doPost(`${this.url}/api/v1/meetings`, {channel_id: channelId, personal, topic, meeting_id: meetingId});
     }
 
+    enrichMeetingJwt = async (meetingJwt) => {
+        return this.doPost(`${this.url}/api/v1/meetings/enrich`, {jwt: meetingJwt});
+    }
+
     doPost = async (url, body, headers = {}) => {
         headers['X-Requested-With'] = 'XMLHttpRequest';
 

--- a/webapp/src/components/post_type_jitsi/index.js
+++ b/webapp/src/components/post_type_jitsi/index.js
@@ -3,6 +3,7 @@ import {bindActionCreators} from 'redux';
 
 import {getBool} from 'mattermost-redux/selectors/entities/preferences';
 import {displayUsernameForUser} from '../../utils/user_utils';
+import {enrichMeetingJwt} from '../../actions';
 
 import PostTypeJitsi from './post_type_jitsi.jsx';
 
@@ -20,6 +21,7 @@ function mapStateToProps(state, ownProps) {
 function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
+            enrichMeetingJwt
         }, dispatch)
     };
 }

--- a/webapp/src/components/post_type_jitsi/post_type_jitsi.jsx
+++ b/webapp/src/components/post_type_jitsi/post_type_jitsi.jsx
@@ -13,21 +13,6 @@ export default class PostTypeJitsi extends React.PureComponent {
          */
         post: PropTypes.object.isRequired,
 
-        /**
-         * Set to render post body compactly.
-         */
-        compactDisplay: PropTypes.bool,
-
-        /**
-         * Flags if the post_message_view is for the RHS (Reply).
-         */
-        isRHS: PropTypes.bool,
-
-        /**
-         * Set to display times using 24 hours.
-         */
-        useMilitaryTime: PropTypes.bool,
-
         /*
          * Logged in user's theme.
          */
@@ -36,20 +21,35 @@ export default class PostTypeJitsi extends React.PureComponent {
         /*
          * Creator's name.
          */
-        creatorName: PropTypes.string.isRequired
+        creatorName: PropTypes.string.isRequired,
+
+        /*
+         * Actions
+         */
+        actions: PropTypes.shape({
+            enrichMeetingJwt: PropTypes.func.isRequired
+        }).isRequired
     };
 
     static defaultProps = {
-        mentionKeys: [],
-        compactDisplay: false,
-        isRHS: false
+        mentionKeys: []
     };
 
     constructor(props) {
         super(props);
 
         this.state = {
+            meetingJwt: null
         };
+    }
+
+    componentDidMount() {
+        const {post} = this.props;
+        if (post.props.jwt_meeting) {
+            this.props.actions.enrichMeetingJwt(post.props.meeting_jwt).then((response) => {
+                this.setState({meetingJwt: response.data.jwt});
+            });
+        }
     }
 
     render() {
@@ -59,6 +59,13 @@ export default class PostTypeJitsi extends React.PureComponent {
 
         let subtitle;
 
+        let meetingLink = props.meeting_link;
+        if (this.state.meetingJwt) {
+            meetingLink += '?jwt=' + this.state.meetingJwt;
+        } else if (props.jwt_meeting) {
+            meetingLink += '?jwt=' + props.meeting_jwt;
+        }
+
         const preText = `${this.props.creatorName} has started a meeting`;
         const content = (
             <div>
@@ -67,7 +74,7 @@ export default class PostTypeJitsi extends React.PureComponent {
                     style={style.button}
                     target='_blank'
                     rel='noopener noreferrer'
-                    href={props.meeting_link}
+                    href={meetingLink}
                 >
                     <i
                         style={style.buttonIcon}
@@ -88,7 +95,7 @@ export default class PostTypeJitsi extends React.PureComponent {
                     <a
                         target='_blank'
                         rel='noopener noreferrer'
-                        href={props.meeting_link}
+                        href={meetingLink}
                     >
                         {props.meeting_id}
                     </a>
@@ -101,7 +108,7 @@ export default class PostTypeJitsi extends React.PureComponent {
                     <a
                         target='_blank'
                         rel='noopener noreferrer'
-                        href={props.meeting_link}
+                        href={meetingLink}
                     >
                         {props.meeting_id}
                     </a>


### PR DESCRIPTION
This PR includes the machinery necesary to populate the user information in the
jwt. It uses the frontend code that displays the jitsi meeting post to request
the plugin an enriched version of the JWT with my user data in it. This way the
link shown to me, is to enter in the meeting with my mattermost user
information.