### PR TITLE
Rename "/meet" command to "/jitsi"

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -8,7 +8,7 @@ import (
 	"github.com/mattermost/mattermost-server/v5/plugin"
 )
 
-const jitsiCommand = "meet"
+const jitsiCommand = "jitsi"
 
 func commandError(channelId string, detailedError string) (*model.CommandResponse, *model.AppError) {
 	return &model.CommandResponse{


### PR DESCRIPTION
If a server has more than one vide plugin enabled, it may not be clear which command `/meet` applies to.

~~cc @jespino I don't seem to have permissions for this repo, so can't tag you as a reviewer~~
cc @seansackowitz for visibility