### PR TITLE
Added missing closing square bracket for german translation

### DIFF
--- a/assets/i18n/active.de.json
+++ b/assets/i18n/active.de.json
@@ -93,6 +93,6 @@
   },
   "jitsi.start_meeting.slack_attachment_text": {
     "hash": "sha1-7726587ccfee9bb7539aad458c154f8be3d95dcd",
-    "other": "{{.MeetingType}}: [{{.MeetingID}}]({{.MeetingURL}})\n\n[Tritt Meeting bei({{.MeetingURL}})"
+    "other": "{{.MeetingType}}: [{{.MeetingID}}]({{.MeetingURL}})\n\n[Tritt Meeting bei]({{.MeetingURL}})"
   }
 }


### PR DESCRIPTION
#### Summary
The German translation misses a closing square bracket for the invitation post. The invitation on mobile devices is broken.
