### PR TITLE
GH-154: Fix Linting issue with Replace and ReplaceAll

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -173,7 +173,7 @@ func (p *Plugin) executeHelpCommand(c *plugin.Context, args *model.CommandArgs) 
 		},
 	})
 
-	text := helpTitle + strings.Replace(commandHelp, "|", "`", -1)
+	text := helpTitle + strings.ReplaceAll(commandHelp, "|", "`")
 	post := &model.Post{
 		UserId:    p.botID,
 		ChannelId: args.ChannelId,
@@ -226,7 +226,7 @@ func (p *Plugin) executeSettingsCommand(c *plugin.Context, args *model.CommandAr
 		post := &model.Post{
 			UserId:    p.botID,
 			ChannelId: args.ChannelId,
-			Message:   strings.Replace(text, "|", "`", -1),
+			Message:   strings.ReplaceAll(text, "|", "`"),
 		}
 		_ = p.API.SendEphemeralPost(args.UserId, post)
 

--- a/server/command_test.go
+++ b/server/command_test.go
@@ -32,7 +32,7 @@ func TestCommandHelp(t *testing.T) {
 	require.Nil(t, err)
 	p.b = i18nBundle
 
-	helpText := strings.Replace(`###### Mattermost Jitsi Plugin - Slash Command help
+	helpText := strings.ReplaceAll(`###### Mattermost Jitsi Plugin - Slash Command help
 * |/jitsi| - Create a new meeting
 * |/jitsi start [topic]| - Create a new meeting with specified topic
 * |/jitsi help| - Show this help text
@@ -45,7 +45,7 @@ func TestCommandHelp(t *testing.T) {
     * |words|: Random English words in title case (e.g. PlayfulDragonsObserveCuriously)
     * |uuid|: UUID (universally unique identifier)
     * |mattermost|: Mattermost specific names. Combination of team name, channel name and random text in public and private channels; personal meeting name in direct and group messages channels.
-    * |ask|: The plugin asks you to select the name every time you start a meeting`, "|", "`", -1)
+    * |ask|: The plugin asks you to select the name every time you start a meeting`, "|", "`")
 
 	apiMock.On("SendEphemeralPost", "test-user", &model.Post{
 		UserId:    "test-bot-id",

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -355,7 +355,7 @@ func (c Claims) MarshalBinary() (data []byte, err error) {
 
 func encodeJitsiMeetingID(meeting string) string {
 	reg := regexp.MustCompile("[^a-zA-Z0-9-_]+")
-	meeting = strings.Replace(meeting, " ", "-", -1)
+	meeting = strings.ReplaceAll(meeting, " ", "-")
 	return reg.ReplaceAllString(meeting, "")
 }
 


### PR DESCRIPTION

The branch had go-linter issues with use of strings.Replace method with replace count -1 and suggested to use ReplaceAll(...) method instead.

https://github.com/mattermost/mattermost-plugin-jitsi/issues/154

