### PR TITLE
[GH-198] Use Mattermost Username as display name in jitsi

### DIFF
--- a/webapp/src/components/post_type_jitsi/__snapshots__/post_type_jitsi.test.tsx.snap
+++ b/webapp/src/components/post_type_jitsi/__snapshots__/post_type_jitsi.test.tsx.snap
@@ -62,7 +62,7 @@ exports[`PostTypeJitsi should render a post if the post type is not null, and sh
             values={Object {}}
           />
           <a
-            href="http://test-meeting-link/test?jwt=xxxxxxxxxxxx#config.callDisplayName=\\"Test topic\\""
+            href="http://test-meeting-link/test?jwt=xxxxxxxxxxxx#config.callDisplayName=\\"Test topic\\"&userInfo.displayName=\\"First Last\\""
             onClick={[Function]}
             rel="noopener noreferrer"
             target="_blank"
@@ -84,7 +84,7 @@ exports[`PostTypeJitsi should render a post if the post type is not null, and sh
             <div>
               <a
                 className="btn btn-lg btn-primary"
-                href="http://test-meeting-link/test?jwt=xxxxxxxxxxxx#config.callDisplayName=\\"Test topic\\""
+                href="http://test-meeting-link/test?jwt=xxxxxxxxxxxx#config.callDisplayName=\\"Test topic\\"&userInfo.displayName=\\"First Last\\""
                 onClick={[Function]}
                 rel="noopener noreferrer"
                 style={
@@ -207,7 +207,7 @@ exports[`PostTypeJitsi should render a post without token if there is no jwt tok
             values={Object {}}
           />
           <a
-            href="http://test-meeting-link/test#config.callDisplayName=\\"Test topic\\""
+            href="http://test-meeting-link/test#config.callDisplayName=\\"Test topic\\"&userInfo.displayName=\\"First Last\\""
             onClick={[Function]}
             rel="noopener noreferrer"
             target="_blank"
@@ -229,7 +229,7 @@ exports[`PostTypeJitsi should render a post without token if there is no jwt tok
             <div>
               <a
                 className="btn btn-lg btn-primary"
-                href="http://test-meeting-link/test#config.callDisplayName=\\"Test topic\\""
+                href="http://test-meeting-link/test#config.callDisplayName=\\"Test topic\\"&userInfo.displayName=\\"First Last\\""
                 onClick={[Function]}
                 rel="noopener noreferrer"
                 style={
@@ -338,7 +338,7 @@ exports[`PostTypeJitsi should render the a different subtitle if the meeting is 
             values={Object {}}
           />
           <a
-            href="http://test-meeting-link/test?jwt=xxxxxxxxxxxx#config.callDisplayName=\\"Test topic\\""
+            href="http://test-meeting-link/test?jwt=xxxxxxxxxxxx#config.callDisplayName=\\"Test topic\\"&userInfo.displayName=\\"First Last\\""
             onClick={[Function]}
             rel="noopener noreferrer"
             target="_blank"
@@ -360,7 +360,7 @@ exports[`PostTypeJitsi should render the a different subtitle if the meeting is 
             <div>
               <a
                 className="btn btn-lg btn-primary"
-                href="http://test-meeting-link/test?jwt=xxxxxxxxxxxx#config.callDisplayName=\\"Test topic\\""
+                href="http://test-meeting-link/test?jwt=xxxxxxxxxxxx#config.callDisplayName=\\"Test topic\\"&userInfo.displayName=\\"First Last\\""
                 onClick={[Function]}
                 rel="noopener noreferrer"
                 style={

--- a/webapp/src/components/post_type_jitsi/index.ts
+++ b/webapp/src/components/post_type_jitsi/index.ts
@@ -4,10 +4,8 @@ import {bindActionCreators, Dispatch, ActionCreatorsMapObject} from 'redux';
 import {getBool, getTheme} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 import {GenericAction, ActionFunc, ActionResult} from 'mattermost-redux/types/actions';
-
 import {Post} from 'mattermost-redux/types/posts';
 
-import {getCurrentUserId} from 'mattermost-redux/selectors/entities/common';
 import {GlobalState} from '../../types';
 import {displayUsernameForUser} from '../../utils/user_utils';
 import {enrichMeetingJwt, openJitsiMeeting, setUserStatus} from '../../actions';
@@ -20,15 +18,13 @@ type OwnProps = {
 function mapStateToProps(state: GlobalState, ownProps: OwnProps) {
     const post = ownProps.post;
     const creator = state.entities.users.profiles[post.user_id];
-    const currentUser = getCurrentUser(state);
     const config = state['plugins-jitsi'].config;
 
     return {
         ...ownProps,
-        currentUserId: getCurrentUserId(state),
+        currentUser: getCurrentUser(state),
         theme: getTheme(state),
         creatorName: displayUsernameForUser(creator, state.entities.general.config),
-        currentUser,
         useMilitaryTime: getBool(state, 'display_settings', 'use_military_time', false),
         meetingEmbedded: Boolean(config.embedded)
     };

--- a/webapp/src/components/post_type_jitsi/index.ts
+++ b/webapp/src/components/post_type_jitsi/index.ts
@@ -2,6 +2,7 @@ import {connect} from 'react-redux';
 import {bindActionCreators, Dispatch, ActionCreatorsMapObject} from 'redux';
 
 import {getBool, getTheme} from 'mattermost-redux/selectors/entities/preferences';
+import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 import {GenericAction, ActionFunc, ActionResult} from 'mattermost-redux/types/actions';
 
 import {Post} from 'mattermost-redux/types/posts';
@@ -18,14 +19,16 @@ type OwnProps = {
 
 function mapStateToProps(state: GlobalState, ownProps: OwnProps) {
     const post = ownProps.post;
-    const user = state.entities.users.profiles[post.user_id];
+    const creator = state.entities.users.profiles[post.user_id];
+    const currentUser = getCurrentUser(state);
     const config = state['plugins-jitsi'].config;
 
     return {
         ...ownProps,
         currentUserId: getCurrentUserId(state),
         theme: getTheme(state),
-        creatorName: displayUsernameForUser(user, state.entities.general.config),
+        creatorName: displayUsernameForUser(creator, state.entities.general.config),
+        currentUser,
         useMilitaryTime: getBool(state, 'display_settings', 'use_military_time', false),
         meetingEmbedded: Boolean(config.embedded)
     };

--- a/webapp/src/components/post_type_jitsi/post_type_jitsi.test.tsx
+++ b/webapp/src/components/post_type_jitsi/post_type_jitsi.test.tsx
@@ -57,6 +57,10 @@ describe('PostTypeJitsi', () => {
         post: basePost,
         theme,
         creatorName: 'test',
+        currentUser: {
+            first_name: 'First',
+            last_name: 'Last'
+        },
         useMilitaryTime: false,
         meetingEmbedded: false,
         actions

--- a/webapp/src/components/post_type_jitsi/post_type_jitsi.tsx
+++ b/webapp/src/components/post_type_jitsi/post_type_jitsi.tsx
@@ -4,6 +4,8 @@ import {Post} from 'mattermost-redux/types/posts';
 import {Theme} from 'mattermost-redux/types/preferences';
 import {ActionResult} from 'mattermost-redux/types/actions';
 import Constants from 'mattermost-redux/constants/general';
+import {UserProfile} from 'mattermost-redux/types/users';
+import {getFullName} from 'mattermost-redux/utils/user_utils';
 
 import Svgs from '../../constants/svgs';
 
@@ -14,6 +16,7 @@ export type Props = {
     theme: Theme,
     currentUserId: string,
     creatorName: string,
+    currentUser: UserProfile,
     useMilitaryTime: boolean,
     meetingEmbedded: boolean,
     actions: {
@@ -99,7 +102,9 @@ export class PostTypeJitsi extends React.PureComponent<Props, State> {
         if (props.jwt_meeting) {
             meetingLink += '?jwt=' + (props.meeting_jwt);
         }
+
         meetingLink += `#config.callDisplayName="${props.meeting_topic || props.default_meeting_topic}"`;
+        meetingLink += `&userInfo.displayName="${getFullName(this.props.currentUser)}"`;
 
         const preText = (
             <FormattedMessage

--- a/webapp/src/components/post_type_jitsi/post_type_jitsi.tsx
+++ b/webapp/src/components/post_type_jitsi/post_type_jitsi.tsx
@@ -14,9 +14,8 @@ import {makeStyleFromTheme} from 'mattermost-redux/utils/theme_utils';
 export type Props = {
     post?: Post,
     theme: Theme,
-    currentUserId: string,
-    creatorName: string,
     currentUser: UserProfile,
+    creatorName: string,
     useMilitaryTime: boolean,
     meetingEmbedded: boolean,
     actions: {
@@ -53,7 +52,7 @@ export class PostTypeJitsi extends React.PureComponent<Props, State> {
             e.preventDefault();
             if (this.props.post) {
                 // could be improved by using an enum in the future for the status
-                this.props.actions.setUserStatus(this.props.currentUserId, Constants.DND);
+                this.props.actions.setUserStatus(this.props.currentUser.id, Constants.DND);
                 this.props.actions.openJitsiMeeting(this.props.post, this.state.meetingJwt || this.props.post.props.meeting_jwt || null);
             }
         } else if (this.state.meetingJwt) {


### PR DESCRIPTION
#### Summary
Use the Mattermost Username as default display name in Jitsi. Given that the user needs to confirm the display in the loby, there is no need for a setting.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-plugin-jitsi/issues/198
