### PR TITLE
Fix #178: assign moderator to only the user who start the meeting

### DIFF
--- a/server/plugin.go
+++ b/server/plugin.go
@@ -112,8 +112,10 @@ type EnrichMeetingJwtRequest struct {
 // Claims extents cristalhq/jwt standard claims to add jitsi-web-token specific fields
 type Claims struct {
 	jwt.StandardClaims
-	Context Context `json:"context"`
-	Room    string  `json:"room,omitempty"`
+	Context   Context `json:"context"`
+	Room      string  `json:"room,omitempty"`
+	Moderator bool    `json:"moderator,omitempty"`  // only the user started the meeting is moderator
+	CreatorID string  `json:"creator_id,omitempty"` // store id of user who start the meeting
 }
 
 func verifyJwt(secret string, jwtToken string) (*Claims, error) {
@@ -200,6 +202,7 @@ func (p *Plugin) updateJwtUserInfo(jwtToken string, user *model.User) (string, e
 	}
 
 	claims.Context = newContext
+	claims.Moderator = sanitizedUser.Id == claims.CreatorID
 
 	return signClaims(secret, claims)
 }
@@ -280,6 +283,8 @@ func (p *Plugin) startMeeting(user *model.User, channel *model.Channel, meetingI
 		claims.ExpiresAt = jwt.NewNumericDate(meetingLinkValidUntil)
 		claims.Subject = jURL.Hostname()
 		claims.Room = meetingID
+		claims.Moderator = false
+		claims.CreatorID = user.Id
 
 		var err2 error
 		jwtToken, err2 = signClaims(p.getConfiguration().JitsiAppSecret, &claims)

--- a/server/plugin_test.go
+++ b/server/plugin_test.go
@@ -39,6 +39,7 @@ func TestSignClaims(t *testing.T) {
 	claims.ExpiresAt = jwt.NewNumericDate(time.Time{})
 	claims.Subject = "test"
 	claims.Room = "test"
+	claims.Moderator = true
 
 	token, err := signClaims("test-secret", &claims)
 	require.Nil(t, err)


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

